### PR TITLE
patch updates to crawler fetcher

### DIFF
--- a/apps/common/src/python/mediawords/dbi/stories/stories.py
+++ b/apps/common/src/python/mediawords/dbi/stories/stories.py
@@ -214,16 +214,37 @@ def add_story(db: DatabaseHandler, story: dict, feeds_id: int) -> Optional[dict]
 
     [insert_story_urls(db, story, u) for u in (story['url'], story['guid'])]
 
+    #feeds_stories_map partitioned??
+    try:
+        record_exists = db.query(
+            """
+            select 1 from feeds_stories_map where feeds_id = %(a)s and stories_id = %(b)s
+            """,
+            {'a': feeds_id, 'b': story['stories_id']}
+        ).fetchone()
+        if not record_exists:
+            db.query(
+                """
+                insert into feeds_stories_map_p (feeds_id, stories_id)
+                values (%(a)s, %(b)s)
+                """,
+                {'a': feeds_id, 'b': story['stories_id']}
+            )
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        log.error("An error occured when adding story: %s" % story['stories_id'])
+    
     # on conflict does not work with partitioned feeds_stories_map
-    db.query(
-        """
-        insert into feeds_stories_map_p ( feeds_id, stories_id )
-            select %(a)s, %(b)s where not exists (
-                select 1 from feeds_stories_map where feeds_id = %(a)s and stories_id = %(b)s )
-        """,
-        {'a': feeds_id, 'b': story['stories_id']})
+    # db.query(
+    #     """
+    #     insert into feeds_stories_map_p ( feeds_id, stories_id )
+    #         select %(a)s, %(b)s where not exists (
+    #             select 1 from feeds_stories_map where feeds_id = %(a)s and stories_id = %(b)s )
+    #     """,
+    #     {'a': feeds_id, 'b': story['stories_id']})
 
-    db.commit()
+    # db.commit()
 
     log.debug("added story: %s" % story['url'])
 

--- a/apps/crawler-fetcher/Dockerfile
+++ b/apps/crawler-fetcher/Dockerfile
@@ -2,7 +2,7 @@
 # Crawler fetcher
 #
 
-FROM gcr.io/mcback/common:base
+FROM gcr.io/mcback/common:release
 
 # Copy sources
 COPY src/ /opt/mediacloud/src/crawler-fetcher/

--- a/apps/crawler-fetcher/Dockerfile
+++ b/apps/crawler-fetcher/Dockerfile
@@ -2,7 +2,7 @@
 # Crawler fetcher
 #
 
-FROM gcr.io/mcback/common:latest
+FROM gcr.io/mcback/common:base
 
 # Copy sources
 COPY src/ /opt/mediacloud/src/crawler-fetcher/

--- a/apps/crawler-fetcher/src/python/crawler_fetcher/engine.py
+++ b/apps/crawler-fetcher/src/python/crawler_fetcher/engine.py
@@ -133,7 +133,10 @@ def run_fetcher(no_daemon: bool = False) -> None:
         try:
             downloads_id = db.query("SELECT pop_queued_download()").flat()[0]
             if downloads_id:
-                download = db.find_by_id(table='downloads', object_id=downloads_id)
+                try:
+                    download = db.find_by_id(table='downloads', object_id=downloads_id)
+                except McCrawlerFetcherSoftError as ex:
+                    _log_download_error(db=db, download=download, error_message=str(ex))
 
                 idle_timer.stop()
 

--- a/apps/crawler-fetcher/src/python/crawler_fetcher/new_story.py
+++ b/apps/crawler-fetcher/src/python/crawler_fetcher/new_story.py
@@ -1,6 +1,8 @@
 import datetime
 from typing import Optional
 
+from crawler_fetcher.exceptions import McCrawlerFetcherSoftError
+
 from mediawords.db import DatabaseHandler
 from mediawords.dbi.stories.stories import add_story
 from mediawords.util.perl import decode_object_from_bytes_if_needed
@@ -45,8 +47,11 @@ def add_story_and_content_download(db: DatabaseHandler, story: dict, parent_down
     """If the story is new, add it to the database and also add a pending download for the story content."""
     story = decode_object_from_bytes_if_needed(story)
     parent_download = decode_object_from_bytes_if_needed(parent_download)
-
-    story = add_story(db=db, story=story, feeds_id=parent_download['feeds_id'])
+    
+    try:
+        story = add_story(db=db, story=story, feeds_id=parent_download['feeds_id'])
+    except McCrawlerFetcherSoftError as ex:
+        raise McCrawlerFetcherSoftError(f"Error adding story, feed_id:{parent_download['feeds_id']} story_id:{story['url']}: {ex}")
 
     if story:
         if story.get('is_new', False):


### PR DESCRIPTION
Modify the query to insert into `feeds_stories_map`, and add logging.
The `where not exists` check prevents duplicates assuming a partitioned table, but query to check if feed_stories_map is partitioned returns False

`SELECT 
  table_name, 
  pg_get_expr(partrelid, relid) AS partition_expression
FROM pg_partitioned_table 
JOIN pg_class ON pg_class.oid = partrelid 
JOIN pg_namespace ON pg_namespace.oid = relnamespace 
WHERE 
  table_name = 'feeds_stories_map_p' 
  AND nspname = 'public';
`
returns 0 rows, 

The query update solves the Invalid query error

`Invalid query: there is no unique or exclusion constraint matching the ON CONFLICT specification`


