### PR TITLE
Fix #8 -- Update web-proxies to include subdomains and correct port m…

### DIFF
--- a/apps/cliff-annotator-webapp-proxy/Dockerfile
+++ b/apps/cliff-annotator-webapp-proxy/Dockerfile
@@ -2,13 +2,13 @@
 # Proxy to CLIFF annotator, roundrobins between cliff-annotator instances
 #
 
-FROM gcr.io/mcback/nginx-base:latest
+FROM codeforafrica/cs-nginx-base
 
 # Copy configuration
 COPY nginx/include/cliff-annotator-webapp-proxy.conf /etc/nginx/include/
 
 # Web server's port
-EXPOSE 8080
+EXPOSE 80
 
 # Run Nginx
 CMD ["nginx"]

--- a/apps/cliff-annotator-webapp-proxy/nginx/include/cliff-annotator-webapp-proxy.conf
+++ b/apps/cliff-annotator-webapp-proxy/nginx/include/cliff-annotator-webapp-proxy.conf
@@ -1,6 +1,6 @@
 server {
-    listen          8080          default_server;
-    server_name     _;
+    listen          80          default_server;
+    server_name     http://cliff.civicsignal.africa;
 
     location / {
         proxy_pass          http://cliff-annotator:8080;

--- a/apps/cliff-annotator-webapp-proxy/nginx/include/cliff-annotator-webapp-proxy.conf
+++ b/apps/cliff-annotator-webapp-proxy/nginx/include/cliff-annotator-webapp-proxy.conf
@@ -1,5 +1,5 @@
 server {
-    listen          80          default_server;
+    listen          80;
     server_name     http://cliff.civicsignal.africa;
 
     location / {

--- a/apps/cliff-annotator-webapp-proxy/nginx/include/cliff-annotator-webapp-proxy.conf
+++ b/apps/cliff-annotator-webapp-proxy/nginx/include/cliff-annotator-webapp-proxy.conf
@@ -1,6 +1,6 @@
 server {
     listen          80;
-    server_name     http://cliff.civicsignal.africa;
+    server_name     cliff.civicsignal.africa;
 
     location / {
         proxy_pass          http://cliff-annotator:8080;

--- a/apps/nginx-base/Dockerfile
+++ b/apps/nginx-base/Dockerfile
@@ -2,7 +2,7 @@
 # Base image for Nginx
 #
 
-FROM gcr.io/mcback/base:latest
+FROM codeforafrica/cs-base:latest
 
 # Install packages
 RUN \

--- a/apps/nytlabels-annotator-webapp-proxy/Dockerfile
+++ b/apps/nytlabels-annotator-webapp-proxy/Dockerfile
@@ -2,13 +2,13 @@
 # Proxy to NYTLabels annotator, roundrobins between nytlabels-annotator instances
 #
 
-FROM gcr.io/mcback/nginx-base:latest
+FROM codeforafrica/cs-nginx-base
 
 # Copy configuration
 COPY nginx/include/nytlabels-annotator-webapp-proxy.conf /etc/nginx/include/
 
 # Web server's port
-EXPOSE 8080
+EXPOSE 80
 
 # Run Nginx
 CMD ["nginx"]

--- a/apps/nytlabels-annotator-webapp-proxy/nginx/include/nytlabels-annotator-webapp-proxy.conf
+++ b/apps/nytlabels-annotator-webapp-proxy/nginx/include/nytlabels-annotator-webapp-proxy.conf
@@ -1,6 +1,6 @@
 server {
     listen          80;
-    server_name     http://nytlabels.civicsignal.africa;
+    server_name     nytlabels.civicsignal.africa;
 
     location / {
         proxy_pass          http://nytlabels-annotator:8080;

--- a/apps/nytlabels-annotator-webapp-proxy/nginx/include/nytlabels-annotator-webapp-proxy.conf
+++ b/apps/nytlabels-annotator-webapp-proxy/nginx/include/nytlabels-annotator-webapp-proxy.conf
@@ -1,6 +1,6 @@
 server {
-    listen          8080          default_server;
-    server_name     _;
+    listen          80         default_server;
+    server_name     http://nytlabels.civicsignal.africa;
 
     location / {
         proxy_pass          http://nytlabels-annotator:8080;

--- a/apps/nytlabels-annotator-webapp-proxy/nginx/include/nytlabels-annotator-webapp-proxy.conf
+++ b/apps/nytlabels-annotator-webapp-proxy/nginx/include/nytlabels-annotator-webapp-proxy.conf
@@ -1,5 +1,5 @@
 server {
-    listen          80         default_server;
+    listen          80;
     server_name     http://nytlabels.civicsignal.africa;
 
     location / {

--- a/apps/webapp-httpd/Dockerfile
+++ b/apps/webapp-httpd/Dockerfile
@@ -2,7 +2,7 @@
 # Webapp (HTTP server)
 #
 
-FROM gcr.io/mcback/nginx-base:latest
+FROM codeforafrica/cs-nginx-base
 
 # Copy configuration
 COPY nginx/include/webapp-httpd.conf /etc/nginx/include/

--- a/apps/webapp-httpd/nginx/include/webapp-httpd.conf
+++ b/apps/webapp-httpd/nginx/include/webapp-httpd.conf
@@ -1,7 +1,7 @@
 server {
     listen          80          default_server;
-    server_name     _;
-    
+    server_name     http://api.civicsignal.africa;
+
     location / {
 
         set             $upstream   webapp-api:9090;
@@ -31,9 +31,9 @@ server {
 
     # Redirect old sign up pages
     location /login/register {
-        return  301 https://tools.mediacloud.org/#/user/signup;
+        return  301 http://explorer.civicsignal.africa/#/user/signup;
     }
     location /login/forgot {
-        return  301 https://tools.mediacloud.org/#/user/request-password-reset;
+        return  301 http://explorer.civicsignal.africa/#/user/request-password-reset;
     }
 }


### PR DESCRIPTION
This PR Fixes #8 

The PR also makes cleanups to the `webapp-httpd` 

PS: Nginx as of [version 1.19](https://hub.docker.com/_/nginx) support Env variables, however this is not explicitly used here. We're installing Nginx as a `deb` package from the base image. This would require tests on multiple apps, better handled on separate PR on upgrades !!!